### PR TITLE
[DRAFT] feat: add ocr-gcp-cloud-vision example

### DIFF
--- a/ocr-gcp-cloud-vision/README.md
+++ b/ocr-gcp-cloud-vision/README.md
@@ -1,0 +1,88 @@
+<p align="center">
+  <a href="https://nitric.io">
+    <img src="https://raw.githubusercontent.com/nitrictech/nitric/main/docs/assets/nitric-logo.svg" width="120" alt="Nitric Logo"/>
+  </a>
+</p>
+
+<p align="center">
+  A fast & fun way to build portable cloud-native applications
+</p>
+
+<p align="center">
+  <img alt="GitHub release (latest SemVer)" src="https://img.shields.io/github/v/release/nitrictech/nitric?sort=semver">
+  <a href="https://twitter.com/nitric_io">
+    <img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/nitric_io?label=Follow&style=social">
+  </a>
+  <a href="https://nitric.io/chat"><img alt="Discord" src="https://img.shields.io/discord/955259353043173427?label=discord"></a>
+</p>
+
+## Project Description
+
+An example for implementing simple Nitric-based APIs for a mock OCR use-case which uses the Google Cloud Vision API.
+
+## About OCR
+
+OCR (Optical Character Recognition) enables a user to detect and extract text from images and documents.
+
+## User Journeys (exposed API operations)
+
+1. A user should be able to create their user profile.
+2. A user should be able to retrieve details of their user profile. No security patterns like Authorization, Authentication, Identification, etc. have been enforced as the shown APIs are for demonstration purposes only. A sample (written in JavaScript) for security could be found at: [Secure APIs with Auth0](https://nitric.io/docs/guides/getting-started/nodejs/secure-api-auth0)
+3. A user should be able to upload an image (single, for demo purposes). The image upload API should only work for users who have their user profiles created.
+   Note: No Authorization, Authentication, Identification, etc. patterns have been applied and the request is validated just based on the correct UUID (for user profile).
+4. A user should be able to retrieve the text corresponding to the uploaded image; OCR is applied on the image to retrieve text from the image. The detected text is uploaded to the user's profile metadata and the same should be retrievable from the API that returns a user's profile information based on the UUID supplied.
+
+## Where to Run
+
+This Nitric-powered application can be run on any supported provider (AWS, GCP, Azure, etc.). However, since the application makes use of the Google Cloud Vision API, having access to the same is necessary. If extending from this codebase, the Google Cloud Vision API could be replaced by the OCR API of choice.
+
+## Usage - Work In Progress
+
+### Step 1: Install Nitric
+
+Follow the steps in the [installation guide](https://nitric.io/docs/installation)
+
+### Step 2: Setup Google Cloud Vision API
+
+### Step 3: Run your Nitric project locally
+
+Refer to the README located in the language specific version of this project.
+
+### Step 4: Test the locally deployed APIs
+
+### Step 5: Deploy Nitric project on cloud
+
+### Step 6: Test the APIs deployed on cloud
+
+## About Nitric
+
+[Nitric](https://nitric.io) is a framework for rapid development of cloud-native and serverless applications. Define your apps in terms of the resources they need, then write the code for serverless function based APIs, event subscribers and scheduled jobs.
+
+Apps built with Nitric can be deployed to AWS, Azure or Google Cloud all from the same code base so you can focus on your products, not your cloud provider.
+
+Nitric makes it easy to:
+
+- Create smart serverless functions and APIs
+- Build reliable distributed apps that use events and/or queues
+- Securely store and retrieve secrets
+- Read and write files from buckets
+
+## Documentation
+
+The full documentation is available at [nitric.io/docs](https://nitric.io/docs).
+
+We're completely open-source and encourage [code contributions](https://nitric.io/docs/contributions).
+
+## Get in touch
+
+- Ask questions in [GitHub discussions](https://github.com/nitrictech/nitric/discussions)
+
+- Find us on [Twitter](https://twitter.com/nitric_io)
+
+- Send us an [email](mailto:maintainers@nitric.io)
+
+- Jump into our [Discord server](https://nitric.io/chat)
+
+## Disclaimer
+
+This codebase is not production-ready and is meant for demonstration purposes only. The codebase doesn't necessarily cover API design and security best practices.

--- a/ocr-gcp-cloud-vision/python/.gitignore
+++ b/ocr-gcp-cloud-vision/python/.gitignore
@@ -1,0 +1,172 @@
+### Nitric ###
+.nitric/
+
+### Image ###
+*.png
+
+### Pulumi ###
+# Ignore temp build directory for Pulumi
+# Info: https://www.pulumi.com/docs/
+.pulumi/
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/ocr-gcp-cloud-vision/python/Pipfile
+++ b/ocr-gcp-cloud-vision/python/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "OCR GCP Cloud Vision - Nitric IfC Sample"
+
+[packages]
+nitric = "==1.0.2"
+google-cloud-vision = "==3.7.2"
+
+[scripts]
+dev = "watchmedo auto-restart -p '*.py' -R python -- -u"
+
+[dev-packages]
+watchdog = "==4.0.0"

--- a/ocr-gcp-cloud-vision/python/README.md
+++ b/ocr-gcp-cloud-vision/python/README.md
@@ -1,0 +1,91 @@
+<p align="center">
+  <a href="https://nitric.io">
+    <img src="https://raw.githubusercontent.com/nitrictech/nitric/main/docs/assets/nitric-logo.svg" width="120" alt="Nitric Logo"/>
+  </a>
+</p>
+
+<p align="center">
+  A fast & fun way to build portable cloud-native applications
+</p>
+
+<p align="center">
+  <img alt="GitHub release (latest SemVer)" src="https://img.shields.io/github/v/release/nitrictech/nitric?sort=semver">
+  <a href="https://twitter.com/nitric_io">
+    <img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/nitric_io?label=Follow&style=social">
+  </a>
+  <a href="https://nitric.io/chat"><img alt="Discord" src="https://img.shields.io/discord/955259353043173427?label=discord"></a>
+</p>
+
+## Project Description
+
+An example for implementing simple Nitric-based APIs for a mock OCR use-case which uses the Google Cloud Vision API.
+
+## About OCR
+
+OCR (Optical Character Recognition) enables a user to detect and extract text from images and documents.
+
+## User Journeys (exposed API operations)
+
+1. A user should be able to create their user profile.
+2. A user should be able to retrieve details of their user profile. No security patterns like Authorization, Authentication, Identification, etc. have been enforced as the shown APIs are for demonstration purposes only. A sample (written in JavaScript) for security could be found at: [Secure APIs with Auth0](https://nitric.io/docs/guides/getting-started/nodejs/secure-api-auth0)
+3. A user should be able to upload an image (single, for demo purposes). The image upload API should only work for users who have their user profiles created.
+   Note: No Authorization, Authentication, Identification, etc. patterns have been applied and the request is validated just based on the correct UUID (for user profile).
+4. A user should be able to retrieve the text corresponding to the uploaded image; OCR is applied on the image to retrieve text from the image. The detected text is uploaded to the user's profile metadata and the same should be retrievable from the API that returns a user's profile information based on the UUID supplied.
+
+## Where to Run
+
+This Nitric-powered Python application can be run on any supported provider (AWS, GCP, Azure, etc.). However, since the application makes use of the Google Cloud Vision API, having access to the same is necessary. If extending from this codebase, the Google Cloud Vision API could be replaced by the OCR API of choice.
+
+## Usage - Work In Progress
+
+### Step 1: Install Nitric
+
+Follow the steps in the [installation guide](https://nitric.io/docs/installation)
+
+### Step 2: Setup Google Cloud Vision API
+
+### Step 3: Run your Nitric project locally
+
+```bash
+pipenv install --dev
+nitric start
+```
+
+### Step 4: Test the locally deployed APIs
+
+### Step 5: Deploy Nitric project on cloud
+
+### Step 6: Test the APIs deployed on cloud
+
+## About Nitric
+
+[Nitric](https://nitric.io) is a framework for rapid development of cloud-native and serverless applications. Define your apps in terms of the resources they need, then write the code for serverless function based APIs, event subscribers and scheduled jobs.
+
+Apps built with Nitric can be deployed to AWS, Azure or Google Cloud all from the same code base so you can focus on your products, not your cloud provider.
+
+Nitric makes it easy to:
+
+- Create smart serverless functions and APIs
+- Build reliable distributed apps that use events and/or queues
+- Securely store and retrieve secrets
+- Read and write files from buckets
+
+## Documentation
+
+The full documentation is available at [nitric.io/docs](https://nitric.io/docs).
+
+We're completely open-source and encourage [code contributions](https://nitric.io/docs/contributions).
+
+## Get in touch
+
+- Ask questions in [GitHub discussions](https://github.com/nitrictech/nitric/discussions)
+
+- Find us on [Twitter](https://twitter.com/nitric_io)
+
+- Send us an [email](mailto:maintainers@nitric.io)
+
+- Jump into our [Discord server](https://nitric.io/chat)
+
+## Disclaimer
+
+This codebase is not production-ready and is meant for demonstration purposes only. The codebase doesn't necessarily cover API design and security best practices.

--- a/ocr-gcp-cloud-vision/python/nitric.yaml
+++ b/ocr-gcp-cloud-vision/python/nitric.yaml
@@ -1,0 +1,6 @@
+name: ocr-gcp-cloud-vision
+services:
+    - match: services/*.py
+      runtime: ""
+      type: ""
+      start: pipenv run dev $SERVICE_PATH

--- a/ocr-gcp-cloud-vision/python/services/ocr.py
+++ b/ocr-gcp-cloud-vision/python/services/ocr.py
@@ -1,0 +1,256 @@
+"""
+About the Module:
+Module for implementing simple Nitric-based APIs for
+a mock OCR use-case which uses the Google Cloud Vision API.
+
+About OCR:
+OCR (Optical Character Recognition) enables a user
+to detect and extract text from images and documents.
+
+User Journeys (exposed API operations):
+1. A user should be able to create their user profile.
+2. A user should be able to retrieve details of their user profile.
+No security patterns like Authorization, Authentication, Identification, etc.
+have been enforced as the shown APIs are for demonstration purposes only.
+A sample (written in JavaScript) for security could be found at:
+https://nitric.io/docs/guides/getting-started/nodejs/secure-api-auth0
+3. A user should be able to upload an image (single, for demo purposes).
+The image upload API should only work for users who have their
+user profiles created.
+Note: No Authorization, Authentication, Identification, etc. patterns
+have been applied and the request is validated just based on the correct
+UUID (for user profile).
+4. A user should be able to retrieve the text corresponding to the
+uploaded image; OCR is applied on the image to retrieve text from the image.
+The detected text is uploaded to the user's profile metadata and the same
+should be retrievable from the API that returns a user's profile information
+based on the UUID supplied.
+
+Where to Run:
+This Nitric-powered Python application can be run on any supported
+provider (AWS, GCP, Azure, etc.). However, since the application makes
+use of the Google Cloud Vision API, having access to the same is necessary.
+If extending from this codebase, the Google Cloud Vision API could be replaced
+by the OCR API of choice.
+
+Disclaimer:
+This codebase is not production-ready and is meant
+for demonstration purposes only. The codebase doesn't necessarily
+cover API design and security best practices.
+"""
+
+# Import the built-in Python packages/libraries.
+import json
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+# Import the third-party Python packages/libraries or SDKs.
+from google.cloud import vision
+from nitric.application import Nitric
+from nitric.context import HttpContext
+from nitric.resources import api, bucket, kv
+
+# Create a Nitric-powered API for the mock OCR use-case.
+ocr_api = api("ocr-api")
+
+# Create a Nitric-powered Key-Value Store for storing users'
+# profiles and related metadata.
+# Also, define the IAM permission categories for the permissions
+# which the Python application should be having to the Key-Value
+# Store; 'get' and 'set' permissions have been given for the
+# 'user_profiles_kv' Key-Value Store.
+user_profiles_kv = kv("user_profiles_kv").allow("get", "set")
+
+# Create a Nitric-powered Storage Bucket for storing photos
+# which the users could be uploading.
+# A user can upload only one photo, as of this demo.
+# `reading` and `writing` permissions should be provided
+# to this Python application for performing read/write
+# operations on the Storage Bucket.
+photo_bucket = bucket("photos")
+photos = photo_bucket.allow("reading", "writing")
+
+
+@ocr_api.post("/profiles")
+async def create_user_profile(ctx: HttpContext) -> None:
+    """
+    A POST API to create a user's profile and store
+    it in a Key-Value store.
+
+    Args:
+        ctx (HttpContext): HTTP Request and Response context for the API.
+    """
+    # Generate a unique profile id for the user.
+    user_profile_id = str(uuid4())
+
+    # Initialize a set of JSON keys which should be present in the
+    # HTTP Request Payload.
+    required_json_payload_keys = {"name", "age", "city"}
+
+    # If HTTP Request JSON Payload is not empty, proceed with user profile
+    # creation, else return an error.
+    if ctx.req.json is not None:
+        # Check the difference between the desired HTTP Request JSON Payload
+        # keys and the ones sent over the actual HTTP Request.
+        missing_json_payload_keys = required_json_payload_keys - set(ctx.req.json)
+
+        # If any required keys are missing in the HTTP Request JSON Payload,
+        # return an HTTP 400 Bad Request response.
+        if missing_json_payload_keys:
+            ctx.res.status = 400
+            ctx.res.body = {
+                "msg": f"Bad Request. Missing required keys: {missing_json_payload_keys}."
+            }
+            # Return `None` to break the flow and return the intended response.
+            return
+    else:
+        # Return an HTTP 400 Bad Request response in case the HTTP Request JSON Payload
+        # is empty.
+        ctx.res.status = 400
+        ctx.res.body = {
+            "msg": f"Bad Request. Missing required keys: {required_json_payload_keys}."
+        }
+        # Return `None` to break the flow and return the intended response.
+        return
+
+    # Store the user profile details in the Key-Value Store.
+    # It should be noted that a Python dictionary is expected as the value for the key.
+    # Therefore, when retrieving the data from the Key-Value Store, if JSON processing needs to
+    # be done, a `json.dumps(data)` would help.
+    try:
+        await user_profiles_kv.set(
+            user_profile_id,
+            {
+                "name": ctx.req.json["name"],
+                "age": ctx.req.json["age"],
+                "city": ctx.req.json["city"],
+            },
+        )
+
+        # Return an HTTP 200 OK message stating that the creation of the user profile
+        # happened successfully.
+        ctx.res.body = {
+            "msg": f"Profile with id '{user_profile_id}' created successfully."
+        }
+        # Return `None` to break the flow and return the intended response.
+        return
+    except Exception:
+        # Return an HTTP 500 Internal Server Error response in case the Key-Value Store
+        # specific `set` operation didn't succeed.
+        ctx.res.status = 500
+        ctx.res.body = {
+            "msg": "An Internal Server Error happened. User profile creation failed."
+        }
+        # Return `None` to break the flow and return the intended response.
+        return
+
+
+@ocr_api.get("/profiles/:id")
+async def get_user_profile(ctx: HttpContext) -> None:
+    """
+    A GET API to retrieve a user's profile details.
+
+    Args:
+        ctx (HttpContext): HTTP Request and Response context for the API.
+    """
+    # Get the profile id of the user from the HTTP Request.
+    user_profile_id = ctx.req.params["id"]
+
+    # Retrieve the details for the user's profile.
+    try:
+        profile_details = await user_profiles_kv.get(user_profile_id)
+        ctx.res.headers["Content-Type"] = "application/json"
+        ctx.res.body = f"{json.dumps(profile_details)}"
+    except Exception:
+        # Return an HTTP 500 Internal Server Error response in case the Key-Value Store
+        # specific `get` operation didn't succeed.
+        ctx.res.status = 500
+        ctx.res.body = {
+            "msg": "An Internal Server Error happened. User profile couldn't be fetched or doesn't exist."
+        }
+        return
+
+
+@ocr_api.get("/profiles/:id/image/upload")
+async def upload_image(ctx: HttpContext) -> None:
+    """
+    A GET API to retrieve a Signed URL for uploading
+    the image.
+
+    Args:
+        ctx (HttpContext): HTTP Request and Response context for the API.
+    """
+    # Get the profile id of the user from the HTTP Request.
+    user_profile_id = ctx.req.params["id"]
+
+    # Generate a Signed URL which is valid for a defined duration.
+    # It should be noted that having user identifiable information in
+    # the URL or HTTP Payload is not a good security practice and could expose the APIs
+    # to OWASP API and Web Application exploits. The shown Signed URL
+    # generation scheme is just for demonstration purposes.
+    photo_url = await photos.file(f"images/{user_profile_id}/photo.png").upload_url(
+        expiry=timedelta(seconds=(3600))
+    )
+
+    # Set the expiry duration so that the same can be passed in the HTTP Response
+    # headers.
+    expires = (datetime.now(UTC) + timedelta(seconds=(3600))).strftime(
+        "%a, %d %b %Y %H:%M:%S GMT"
+    )
+    ctx.res.headers["Expires"] = expires
+
+    # Set the HTTP Response body.
+    ctx.res.body = photo_url
+
+
+@photo_bucket.on("write", "images")
+async def on_photo_upload(ctx) -> None:
+    """
+    A Storage Bucket Notification Trigger that performs
+    OCR on the uploaded image and updates the user's profile in
+    the Key-Value Store.
+
+    Args:
+        ctx (_type_): Context for the bucket notification trigger.
+
+    Raises:
+        Exception: Raise an exception in case the OCR API'ss response returned an error.
+    """
+    # Instantiate the Image Annotator Client for Google Cloud Vision API.
+    client = vision.ImageAnnotatorClient()
+
+    # Get the context of the request and retrieve the name of the image that
+    # got written to the Storage Bucket.
+    content = await photos.file(ctx.req.key).read()
+
+    # Define the image to perform OCR operation on.
+    image = vision.Image(content=content)
+
+    # Perform text detection on the uploaded image and store the text response.
+
+    response = client.text_detection(image=image)  # pylint: disable=no-member
+
+    # Retrieve the text annotations from the OCR's response.
+    texts = response.text_annotations
+
+    # Raise an exception in case the OCR API's response returned an error.
+    if response.error.message:
+        raise Exception(
+            f"{response.error.message} - For more info on error messages, check out: 'https://cloud.google.com/apis/design/errors'."
+        )
+
+    # Retrieve the user's profile id from the context.
+    user_profile_id = str(ctx.req.key.split("/")[1])
+
+    # Retrieve user's profile details from the Key-Value Store.
+    user_profile_details = await user_profiles_kv.get(user_profile_id)
+
+    # Update the user's profile details in the Key-Value Store with the annotated text.
+    user_profile_details["annotated_text"] = texts[0].description.replace("\n", " ")
+
+    # Update the 'user_profiles_kv' with the annotated text for the uploaded image.
+    await user_profiles_kv.set(user_profile_id, user_profile_details)
+
+
+# Start the Nitric application.
+Nitric.run()


### PR DESCRIPTION
Added an example (written in Python) for performing OCR on images using Google Cloud Vision API.
This Nitric-powered Python application can be run on any supported provider (AWS, GCP, Azure, etc.). However, since the application makes use of the Google Cloud Vision API, having access to the same is necessary. If extending from this codebase, the Google Cloud Vision API could be replaced by the OCR API of choice.